### PR TITLE
Adding timeScale and extent

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,26 +628,50 @@ instance scaleTime :: Scale TimeScale
 
 
 
+## Module Graphics.D3.Unsafe
+
+
 ## Module Graphics.D3.Util
+
+#### `Magnitude`
+
+``` purescript
+class Magnitude n where
+```
+
+
+#### `numberMagnitude`
+
+``` purescript
+instance numberMagnitude :: Magnitude Number
+```
+
+
+#### `dateMagnitude`
+
+``` purescript
+instance dateMagnitude :: Magnitude JSDate
+```
+
 
 #### `min`
 
 ``` purescript
-min :: forall d. (d -> Number) -> [d] -> Number
+min :: forall d m. (Magnitude m) => (d -> m) -> [d] -> m
 ```
 
 
 #### `max`
 
 ``` purescript
-max :: forall d. (d -> Number) -> [d] -> Number
+max :: forall d m. (Magnitude m) => (d -> m) -> [d] -> m
 ```
 
 
 #### `extent`
 
 ``` purescript
-extent :: forall d. [d] -> [d]
+extent :: forall m. (Magnitude m) => [m] -> [m]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -654,6 +654,20 @@ instance dateMagnitude :: Magnitude JSDate
 ```
 
 
+#### `min'`
+
+``` purescript
+min' :: forall d m. (Magnitude m) => (d -> m) -> [d] -> m
+```
+
+
+#### `max'`
+
+``` purescript
+max' :: forall d m. (Magnitude m) => (d -> m) -> [d] -> m
+```
+
+
 #### `min`
 
 ``` purescript

--- a/README.md
+++ b/README.md
@@ -657,14 +657,14 @@ instance dateMagnitude :: Magnitude JSDate
 #### `min`
 
 ``` purescript
-min :: forall d m. (Magnitude m) => (d -> m) -> [d] -> m
+min :: forall m. (Magnitude m) => [m] -> m
 ```
 
 
 #### `max`
 
 ``` purescript
-max :: forall d m. (Magnitude m) => (d -> m) -> [d] -> m
+max :: forall d m. (Magnitude m) => [m] -> m
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -604,6 +604,30 @@ instance clickableSelection :: Clickable (Selection a)
 
 
 
+## Module Graphics.D3.Time
+
+#### `TimeScale`
+
+``` purescript
+data TimeScale :: * -> * -> *
+```
+
+
+#### `timeScale`
+
+``` purescript
+timeScale :: forall r. D3Eff (TimeScale JSDate r)
+```
+
+
+#### `scaleTime`
+
+``` purescript
+instance scaleTime :: Scale TimeScale
+```
+
+
+
 ## Module Graphics.D3.Util
 
 #### `min`
@@ -619,6 +643,12 @@ min :: forall d. (d -> Number) -> [d] -> Number
 max :: forall d. (d -> Number) -> [d] -> Number
 ```
 
+
+#### `extent`
+
+``` purescript
+extent :: forall d. [d] -> [d]
+```
 
 
 ## Module Graphics.D3.Layout.Base

--- a/bower.json
+++ b/bower.json
@@ -11,8 +11,13 @@
   "dependencies": {
     "d3": "^3.4.9",
     "purescript-easy-ffi": "^1.0.0",
-    "purescript-foreign": "~0.3.0"
+    "purescript-foreign": "~0.3.0",
+    "purescript-datetime": "^0.5.1"
   },
   "main": "src/**/*.purs",
-  "private": false
+  "private": false,
+  "resolutions": {
+    "purescript-tuples": "~0.3.0",
+    "purescript-monoid": "~0.2.0"
+  }
 }

--- a/src/Scale.purs
+++ b/src/Scale.purs
@@ -32,6 +32,7 @@ module Graphics.D3.Scale
 
 import Graphics.D3.Base
 import Graphics.D3.Interpolate
+import Graphics.D3.Unsafe
 
 import Data.Tuple
 import Data.Maybe
@@ -168,10 +169,6 @@ instance scaleOrdinal :: Scale OrdinalScale where
   copy = unsafeCopy
   toFunction = unsafeToFunction
 
-unsafeDomain = ffi ["domain", "scale", ""] "scale.domain(domain)"
-unsafeRange = ffi ["values", "scale", ""] "scale.range(values)"
-unsafeCopy = ffi ["scale", ""] "scale.copy()"
-unsafeToFunction = ffi ["scale", ""] "scale.copy()"
 unsafeInvert = ffi ["scale", ""] "scale.copy().invert"
 unsafeRangeRound = ffi ["values", "scale", ""] "scale.rangeRound(values)"
 unsafeInterpolate = ffi ["factory", "scale", ""] "scale.interpolate(factory)"

--- a/src/Time.purs
+++ b/src/Time.purs
@@ -6,6 +6,7 @@ import Data.Foreign.EasyFFI
 import Data.Date
 import Graphics.D3.Base
 import Graphics.D3.Scale
+import Graphics.D3.Unsafe
 
 foreign import data TimeScale :: * -> * -> *
 foreign import timeScale "var timeScale = d3.time.scale"
@@ -16,9 +17,3 @@ instance scaleTime :: Scale TimeScale where
   range = unsafeRange
   copy = unsafeCopy
   toFunction = unsafeToFunction
-
-ffi = unsafeForeignFunction
-unsafeDomain = ffi ["domain", "scale", ""] "scale.domain(domain)"
-unsafeRange = ffi ["values", "scale", ""] "scale.range(values)"
-unsafeCopy = ffi ["scale", ""] "scale.copy()"
-unsafeToFunction = ffi ["scale", ""] "scale.copy()"

--- a/src/Time.purs
+++ b/src/Time.purs
@@ -1,0 +1,24 @@
+module Graphics.D3.Time (
+	TimeScale(),
+	timeScale
+  ) where
+import Data.Foreign.EasyFFI
+import Data.Date
+import Graphics.D3.Base
+import Graphics.D3.Scale
+
+foreign import data TimeScale :: * -> * -> *
+foreign import timeScale "var timeScale = d3.time.scale"
+  :: forall r. D3Eff (TimeScale JSDate r)
+
+instance scaleTime :: Scale TimeScale where
+  domain = unsafeDomain
+  range = unsafeRange
+  copy = unsafeCopy
+  toFunction = unsafeToFunction
+
+ffi = unsafeForeignFunction
+unsafeDomain = ffi ["domain", "scale", ""] "scale.domain(domain)"
+unsafeRange = ffi ["values", "scale", ""] "scale.range(values)"
+unsafeCopy = ffi ["scale", ""] "scale.copy()"
+unsafeToFunction = ffi ["scale", ""] "scale.copy()"

--- a/src/Unsafe.purs
+++ b/src/Unsafe.purs
@@ -1,0 +1,15 @@
+module Graphics.D3.Unsafe (
+	unsafeDomain,
+	unsafeRange,
+	unsafeCopy,
+	unsafeToFunction
+  ) where
+
+import Data.Foreign.EasyFFI
+
+ffi = unsafeForeignFunction
+
+unsafeDomain = ffi ["domain", "scale", ""] "scale.domain(domain)"
+unsafeRange = ffi ["values", "scale", ""] "scale.range(values)"
+unsafeCopy = ffi ["scale", ""] "scale.copy()"
+unsafeToFunction = ffi ["scale", ""] "scale.copy()"

--- a/src/Util.purs
+++ b/src/Util.purs
@@ -2,6 +2,8 @@ module Graphics.D3.Util
   ( Magnitude
   , min
   , max
+  , min'
+  , max'
   , extent
   , (..)
   , (...)

--- a/src/Util.purs
+++ b/src/Util.purs
@@ -34,6 +34,9 @@ max = unsafeForeignFunction ["data"] "d3.max(data)"
 extent :: forall m. (Magnitude m) => [m] -> [m]
 extent = unsafeForeignFunction ["data"] "d3.extent(data)"
 
+extent' :: forall d m. (Magnitude m) => (d->m) -> [d] -> [m]
+extent' = unsafeForeignFunction ["fn", "data"] "d3.extent(data, fn)"
+
 -- Syntactic sugar to make chained monadic statements look similar to the
 -- "fluid interface" style of chained method calls in JavaScript
 (..) = (>>=)

--- a/src/Util.purs
+++ b/src/Util.purs
@@ -15,11 +15,17 @@ class Magnitude n
 instance numberMagnitude :: Magnitude Number
 instance dateMagnitude :: Magnitude JSDate
 
-min :: forall d m. (Magnitude m) => (d -> m) -> [d] -> m
-min = unsafeForeignFunction ["fn", "data"] "d3.min(data, fn)"
+min' :: forall d m. (Magnitude m) => (d -> m) -> [d] -> m
+min' = unsafeForeignFunction ["fn", "data"] "d3.min(data, fn)"
 
-max :: forall d m. (Magnitude m) => (d -> m) -> [d] -> m
-max = unsafeForeignFunction ["fn", "data"] "d3.max(data, fn)"
+max' :: forall d m. (Magnitude m) => (d -> m) -> [d] -> m
+max' = unsafeForeignFunction ["fn", "data"] "d3.max(data, fn)"
+
+min :: forall m. (Magnitude m) => [m] -> m
+min = unsafeForeignFunction ["data"] "d3.min(data)"
+
+max :: forall d m. (Magnitude m) => [m] -> m
+max = unsafeForeignFunction ["data"] "d3.max(data)"
 
 -- extent takes a data array and returns [min,max]
 -- not restricted to Number, i.e. also works with time

--- a/src/Util.purs
+++ b/src/Util.purs
@@ -5,6 +5,7 @@ module Graphics.D3.Util
   , min'
   , max'
   , extent
+  , extent'
   , (..)
   , (...)
   ) where

--- a/src/Util.purs
+++ b/src/Util.purs
@@ -1,6 +1,7 @@
 module Graphics.D3.Util
   ( min
   , max
+  , extent
   , (..)
   , (...)
   ) where
@@ -12,6 +13,11 @@ min = unsafeForeignFunction ["fn", "data"] "d3.min(data, fn)"
 
 max :: forall d. (d -> Number) -> [d] -> Number
 max = unsafeForeignFunction ["fn", "data"] "d3.max(data, fn)"
+
+-- extent takes a data array and returns [min,max]
+-- not restricted to Number, i.e. also works with time
+extent :: forall d. [d] -> [d]
+extent = unsafeForeignFunction ["data"] "d3.extent(data)"
 
 -- Syntactic sugar to make chained monadic statements look similar to the
 -- "fluid interface" style of chained method calls in JavaScript

--- a/src/Util.purs
+++ b/src/Util.purs
@@ -1,5 +1,6 @@
 module Graphics.D3.Util
-  ( min
+  ( Magnitude
+  , min
   , max
   , extent
   , (..)
@@ -7,16 +8,22 @@ module Graphics.D3.Util
   ) where
 
 import Data.Foreign.EasyFFI
+import Data.Date
 
-min :: forall d. (d -> Number) -> [d] -> Number
+class Magnitude n
+
+instance numberMagnitude :: Magnitude Number
+instance dateMagnitude :: Magnitude JSDate
+
+min :: forall d m. (Magnitude m) => (d -> m) -> [d] -> m
 min = unsafeForeignFunction ["fn", "data"] "d3.min(data, fn)"
 
-max :: forall d. (d -> Number) -> [d] -> Number
+max :: forall d m. (Magnitude m) => (d -> m) -> [d] -> m
 max = unsafeForeignFunction ["fn", "data"] "d3.max(data, fn)"
 
 -- extent takes a data array and returns [min,max]
 -- not restricted to Number, i.e. also works with time
-extent :: forall d. [d] -> [d]
+extent :: forall m. (Magnitude m) => [m] -> [m]
 extent = unsafeForeignFunction ["data"] "d3.extent(data)"
 
 -- Syntactic sugar to make chained monadic statements look similar to the


### PR DESCRIPTION
This is my first non-trivial purescript effort so please review and comment (gently :) )!

There's two things I guess could be improved but I don't know how precisely:

I put the time stuff in a new module `Graphics.D3.Time` defined in `time.purs`.  It could also go in `Scale` which would mean we wouldn't need to redefine `unsafeDomain`, `unsafeRange`, etc.  However, there's loads more time stuff to come so I guess it makes sense to separate it now?
What is the correct way to share these `unsafe` definitions between Time and Scale without exposing them outside the library?

Also, I left the `extent` type parameter completely general so it can work with Number or JSDate.  What is the correct way to specify a "this type or that" constraint?

Here's the example I'm working on which uses these added bindings:

```
module Graphics.D3.Examples.UpdateGraph where

import Data.Either
import Data.Traversable
import Data.Date
import Data.Foreign
import Data.Foreign.EasyFFI

import Graphics.D3.Base
import Graphics.D3.Util
import Graphics.D3.Selection
import Graphics.D3.SVG.Axis
import Graphics.D3.Scale
import Graphics.D3.Time
import Graphics.D3.Request

-- | This is a PureScript adaptation of d3noob's example: "Update graph data automatically"
-- | http://bl.ocks.org/d3noob/6bd13f974d6516f3e491

{-

Original JavaScript code:
=========================

-}

type DateAndClose = { date :: JSDate, close :: Number }

coerceDatum :: forall a. a -> D3Eff DateAndClose
coerceDatum = unsafeForeignFunction ["x", ""] "{ date: d3.time.format('%d-%b-%y').parse(x.date), close: Number(x.close) }"

margin = {top: 30, right: 20, bottom: 30, left: 50}
width = 600 - margin.left - margin.right
height = 270 - margin.top - margin.bottom

-- valueline = ffi ["xdata", "ydata", ""] "d3.svg.line().x(xdata).y(ydata);"
close x = x.close
date x = x.date

main = do

  xScale <- timeScale
    .. range [0, width]

  yScale <- linearScale
    .. range [height, 0]

-- Define the axes
  xAxis <- axis
    .. scale xScale
    .. orient "bottom"
    .. ticks 5

  yAxis <- axis
    .. scale yScale
    .. orient "left"
    .. ticks 5

  svg <- rootSelect "body" .. append "svg"
    .. attr "width" (width + margin.left + margin.right)
    .. attr "height" (height + margin.top + margin.bottom)
    .. append "g"
      .. attr "transform" ("translate(" ++ show margin.left ++ "," ++ show margin.top ++ ")")

  csv "data.csv" \(Right array) -> do
    typedData <- traverse coerceDatum array

    xScale ... domain $ extent $ date <$> typedData

    yScale ... domain [0, max close typedData]

    svg ... append "g"
      .. attr "class" "x axis"
      .. attr "transform" ("translate(0," ++ show height ++ ")")
      .. renderAxis xAxis

    svg ... append "g"
      .. attr "class" "y axis"
      .. renderAxis yAxis

    x <- toFunction xScale
    y <- toFunction yScale

    svg ... selectAll "ellipse"
        .. bind typedData
      .. enter .. append "ellipse"
        .. attr "class" "datapoint"
        .. attr' "cx" (x <<< date)
        .. attr' "cy" (y <<< close)
        .. attr "rx" "5"
        .. attr "ry" "5"

    -- let xdata = x <$> (date <$> typedData)
    -- let ydata = y <$> (close <$> typedData)

    --let dd = valueline xdata ydata
    -- svg ... append "path"
    --   .. attr "class" "line"
    --   .. attr "d" dd
```
