### PR TITLE
Click event callback encoding (Eff)

### DIFF
--- a/src/Selection.purs
+++ b/src/Selection.purs
@@ -128,10 +128,10 @@ unsafeText'' = ffi
   "selection.text(function (d, i) { return text(d)(i); })"
 
 unsafeOnClick :: forall eff c i r. (Clickable c) => (i -> Eff eff r) -> c -> D3Eff c
-unsafeOnClick = ffi ["callback", "clickable", ""] "clickable.on('click', callback)"
+unsafeOnClick = ffi ["callback", "clickable", ""] "clickable.on('click', function(data) { callback(data)(); })"
 
 unsafeOnDoubleClick :: forall eff c i r. (Clickable c) => (i -> Eff eff r) -> c -> D3Eff c
-unsafeOnDoubleClick = ffi ["callback", "clickable", ""] "clickable.on('dblclick', callback)"
+unsafeOnDoubleClick = ffi ["callback", "clickable", ""] "clickable.on('dblclick', function (data) { callback(data)(); })"
 
 -- Transition-only stuff
 delay :: forall d. Number -> Transition d -> D3Eff (Transition d)


### PR DESCRIPTION
Encoding of callback didn't actually take the `Eff` into account meaning callback code doesn't actually get run.

(Not sure about the type - seems like it really should be selection data type & maybe index?).
